### PR TITLE
Include poolboy and riak_pool in the release

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -50,6 +50,8 @@
        {app, mysql, [{incl_cond, include}]},
        {app, redo, [{incl_cond, include}]},
        {app, cuesport, [{incl_cond, include}]},
+       {app, poolboy, [{incl_cond, include}]},
+       {app, riak_pool, [{incl_cond, include}]},
        {app, inets, [{incl_cond, include}]},
        {app, exml, [{incl_cond, include}]},
        {app, ranch, [{incl_cond, include}]},


### PR DESCRIPTION
Just noticed that `ejabberd_odbc_sup` requires `poolboy`, so `mod_mam_riak_arch` requires `riak_pool`. The two applications should therefore be included in the release. Not sure if you need them started as well. Please note that I haven't tested at all this file change.